### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 go.work
 
 # Built binary
-pg-lock-check
+/pg-lock-check
 
 # IDE files
 .idea/

--- a/cmd/pg-lock-check/main.go
+++ b/cmd/pg-lock-check/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	version = "0.1.0"
+	version = "0.1.1"
 
 	// Flags
 	fileFlag          string


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.1.1 for upcoming release
- Fix .gitignore to only exclude root binary

## Changes
- Update version constant in main.go to "0.1.1"
- Change `.gitignore` from `pg-lock-check` to `/pg-lock-check` to only exclude the root binary, not the `cmd/pg-lock-check` directory

## Release Notes
This version includes:
- Fixed JSON/YAML output formats (#10)
- Proper structured output with summary and detailed results
- Support for multi-line SQL statements

🤖 Generated with [Claude Code](https://claude.ai/code)