### PR TITLE
feat: implement dual-mode CI for suggestions documentation

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,38 +1,183 @@
-name: Generate Documentation
+name: Suggestions Documentation
 
 on:
-  push:
-    branches: [ main ]
+  # For PRs: Generate and comment
+  pull_request:
     paths:
       - 'internal/suggester/suggestions.yaml'
+      - 'docs/design/suggestions.template.md'
+      - 'scripts/generate-suggestions-doc.sh'
+  
+  # For main: Generate and commit
+  push:
+    branches: [main]
+    paths:
+      - 'internal/suggester/suggestions.yaml'
+      - 'docs/design/suggestions.template.md'
+      - 'scripts/generate-suggestions-doc.sh'
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  generate:
+  # Job 1: Generate and comment on PRs
+  pr-preview:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Install yq
-      run: |
-        sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-        sudo chmod +x /usr/local/bin/yq
-    
-    - name: Generate documentation
-      run: |
-        chmod +x scripts/generate-suggestions-doc.sh
-        ./scripts/generate-suggestions-doc.sh
-    
-    - name: Commit changes
-      run: |
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add docs/design/suggestions.md
-        git diff --staged --quiet || git commit -m "docs: auto-generate suggestions documentation [skip ci]"
-        git push
+      - uses: actions/checkout@v4
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Generate suggestions documentation
+        id: generate
+        run: |
+          # Make script executable
+          chmod +x scripts/generate-suggestions-doc.sh
+          
+          # Run generation and capture both stdout and stderr
+          if ./scripts/generate-suggestions-doc.sh 2>&1 | tee generation.log; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "error<<EOF" >> $GITHUB_OUTPUT
+            cat generation.log >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Read generated documentation
+        if: steps.generate.outputs.success == 'true'
+        id: read_docs
+        run: |
+          # Check file size
+          FILE_SIZE=$(stat -c%s docs/design/suggestions.md 2>/dev/null || stat -f%z docs/design/suggestions.md)
+          echo "file_size=$FILE_SIZE" >> $GITHUB_OUTPUT
+          
+          # Read content with size limit check
+          if [ "$FILE_SIZE" -gt 65000 ]; then
+            echo "content_truncated=true" >> $GITHUB_OUTPUT
+            {
+              echo 'content<<EOF'
+              head -c 60000 docs/design/suggestions.md
+              echo -e "\n\n... (truncated, file too large for comment)"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+          else
+            echo "content_truncated=false" >> $GITHUB_OUTPUT
+            {
+              echo 'content<<EOF'
+              cat docs/design/suggestions.md
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+          fi
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: find_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- suggestions-doc-preview -->'
+
+      - name: Create or update success comment
+        if: steps.generate.outputs.success == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            <!-- suggestions-doc-preview -->
+            ## Suggestions Documentation Preview
+
+            This is how `docs/design/suggestions.md` will look after merging this PR.
+
+            <details>
+            <summary><strong>View generated documentation</strong> (size: ${{ steps.read_docs.outputs.file_size }} bytes)</summary>
+
+            ```markdown
+            ${{ steps.read_docs.outputs.content }}
+            ```
+
+            </details>
+
+            ${{ steps.read_docs.outputs.content_truncated == 'true' && '> **Note**: Content truncated due to size limits. Full file will be generated after merge.' || '' }}
+
+            ---
+            *Generated automatically from suggestions.yaml • Last updated: ${{ github.event.pull_request.head.sha }}*
+          edit-mode: replace
+
+      - name: Create or update error comment
+        if: steps.generate.outputs.success == 'false'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            <!-- suggestions-doc-preview -->
+            ## Documentation Generation Failed
+
+            The suggestions documentation could not be generated due to an error:
+
+            ```
+            ${{ steps.generate.outputs.error }}
+            ```
+
+            **Please fix the error and push again.**
+
+            Common issues:
+            - Syntax errors in `suggestions.yaml`
+            - Template syntax errors in `suggestions.template.md`
+            - Missing required fields in YAML
+
+            ---
+            *Generated automatically • Commit: ${{ github.event.pull_request.head.sha }}*
+          edit-mode: replace
+
+  # Job 2: Generate and commit on main
+  update-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Generate suggestions documentation
+        run: |
+          chmod +x scripts/generate-suggestions-doc.sh
+          ./scripts/generate-suggestions-doc.sh
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet docs/design/suggestions.md; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No changes to suggestions.md"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Changes detected in suggestions.md"
+          fi
+
+      - name: Commit and push if changed
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          git add docs/design/suggestions.md
+          git commit -m "docs: auto-generate suggestions documentation [skip ci]
+
+          Auto-generated from internal/suggester/suggestions.yaml
+          Triggered by: ${{ github.sha }}"
+          git push

--- a/docs/design/suggestions.md
+++ b/docs/design/suggestions.md
@@ -1,0 +1,118 @@
+---
+title: CRITICAL Operations - Safe Migration Patterns
+version: 1.0
+generated_from: internal/suggester/suggestions.yaml
+generated_at: 2025-06-26
+---
+# CRITICAL Operations - Safe Migration Patterns
+
+Based on lock_severity.md, this document maps all CRITICAL severity operations to their safe migration suggestions.
+
+## Available Suggestions Summary
+
+### Operations with Safe Alternatives
+
+| Operation | Category | Migration Steps | Transaction Safe |
+|-----------|----------|-------|------------------|
+| UPDATE without WHERE | DML Operations | Export target row IDs to file;Process file in batches with progress tracking; | ⚠️ Mixed |
+| DELETE without WHERE | DML Operations | Export target row IDs to file;Process file in batches; | ⚠️ Mixed |
+| MERGE without WHERE | DML Operations | Export source data IDs to file;Process MERGE in batches; | ⚠️ Mixed |
+| DROP INDEX | Index Operations | Use `DROP INDEX CONCURRENTLY` outside transaction; | ❌ No |
+| CREATE INDEX | Index Operations | Use `CREATE INDEX CONCURRENTLY` outside transaction; | ❌ No |
+| CREATE UNIQUE INDEX | Index Operations | Use `CREATE UNIQUE INDEX CONCURRENTLY` outside transaction; | ❌ No |
+| REINDEX | Index Operations | Use `REINDEX CONCURRENTLY` or CREATE new index + DROP old pattern; | ❌ No |
+| REINDEX TABLE | Index Operations | Export all index names for the table;Reindex each index individually; | ⚠️ Mixed |
+| REINDEX DATABASE | Index Operations | Export all index names in the database;Reindex each index individually; | ⚠️ Mixed |
+| REINDEX SCHEMA | Index Operations | Export all index names in the schema;Reindex each index individually; | ⚠️ Mixed |
+| ALTER TABLE ADD COLUMN with volatile DEFAULT | ALTER TABLE Operations | `ADD COLUMN` without default;Batch update with default values (separate transactions per batch);`ALTER COLUMN SET DEFAULT`; | ⚠️ Mixed |
+| ALTER TABLE ALTER COLUMN TYPE | ALTER TABLE Operations | Add new column;Add sync trigger;Backfill script;Atomic swap; | ⚠️ Mixed |
+| ALTER TABLE ADD PRIMARY KEY | ALTER TABLE Operations | First `CREATE UNIQUE INDEX CONCURRENTLY`;Then `ALTER TABLE ADD CONSTRAINT pkey PRIMARY KEY USING INDEX`; | ⚠️ Mixed |
+| ALTER TABLE ADD CONSTRAINT CHECK | ALTER TABLE Operations | Use `ADD CONSTRAINT NOT VALID`;Then `VALIDATE CONSTRAINT`; | ✅ Yes |
+| ALTER TABLE SET NOT NULL | ALTER TABLE Operations | `ADD CONSTRAINT CHECK (col IS NOT NULL) NOT VALID`;`VALIDATE CONSTRAINT`;`SET NOT NULL`;Drop constraint; | ✅ Yes |
+| CLUSTER | Maintenance Operations | Consider `pg_repack` extension for online reorganization; | ❌ No |
+| REFRESH MATERIALIZED VIEW | Maintenance Operations | Use `REFRESH MATERIALIZED VIEW CONCURRENTLY` (requires unique index); | ❌ No |
+| VACUUM FULL | Maintenance Operations | Use `pg_repack` extension instead; | ❌ No |
+
+### Operations Without Safe Alternatives
+
+The following CRITICAL operations do not have safe alternatives:
+
+| Operation | Category | Reason |
+|-----------|----------|--------|
+| TRUNCATE | DML Operations | Requires AccessExclusive lock, no workaround |
+| DROP TABLE | DDL Operations | Destructive operation |
+| DROP SCHEMA | DDL Operations | Destructive operation |
+| DROP SCHEMA CASCADE | DDL Operations | Destructive operation |
+| DROP OWNED | DDL Operations | Destructive operation |
+| REINDEX SYSTEM | Index Operations | System catalogs require exclusive access |
+| ALTER TABLE DROP COLUMN | ALTER TABLE Operations | Requires table rewrite |
+| ALTER TABLE SET TABLESPACE | ALTER TABLE Operations | Requires full table lock |
+| ALTER TABLE SET LOGGED/UNLOGGED | ALTER TABLE Operations | Requires table rewrite |
+| ALTER TABLE RENAME TO | ALTER TABLE Operations | Requires exclusive lock |
+| ALTER TABLE SET SCHEMA | ALTER TABLE Operations | Requires exclusive lock |
+| LOCK TABLE ACCESS EXCLUSIVE | Explicit Locking | Explicitly requests exclusive lock |
+| DROP DATABASE | DDL Operations | Requires exclusive database access |
+
+## Summary Statistics
+
+- **Total CRITICAL operations**: 31
+- **Operations with safe alternatives**: 18 (58%)
+- **Operations without safe alternatives**: 13 (41%)
+
+## Prerequisites
+
+- PostgreSQL 13+ (minimum supported version)
+- All CONCURRENTLY operations must run outside transactions
+- Set `lock_timeout` before DDL operations: `SET lock_timeout = '5s';`
+
+## Guidelines
+
+### General
+- All CONCURRENTLY operations **must** run outside transactions (will ERROR in transaction mode)
+- Always set `lock_timeout` for DDL operations: `SET lock_timeout = '5s';`
+- Monitor locks during migration: `SELECT * FROM pg_stat_activity WHERE wait_event_type = 'Lock';`
+
+### Batching
+- **Common pattern**: `SELECT id FROM table WHERE condition \COPY TO '/tmp/ids.csv'` → Process file in script
+- Default batch size: 1000-5000 rows (use `WHERE id IN (...)` with explicit lists)
+- Add sleep delays (100-500ms) between batches
+- Track progress: Line number in file or separate progress table
+- Monitor: Replication lag, lock waits, transaction duration
+- Resume capability: Essential for large tables (millions of rows)
+
+## Version Features Available in PostgreSQL 13+
+
+- CREATE/DROP INDEX CONCURRENTLY
+- REFRESH MATERIALIZED VIEW CONCURRENTLY
+- REINDEX CONCURRENTLY
+- ALTER TABLE ... ADD CONSTRAINT ... NOT VALID
+- Generated columns
+- Partitioned table improvements
+
+## Risk Assessment
+
+| Pattern | Risk Level | Performance Impact | Best For |
+|---------|------------|-------------------|----------|
+| Batched DML | Low | 2-5x slower | Tables > 1M rows |
+| CONCURRENTLY operations | Low | 2-3x slower | Production systems |
+| Blue-green migrations | Low | Requires 2x storage | Complex type changes |
+| NOT VALID + VALIDATE | Low | Minimal | Large tables |
+| pg_repack | Medium | CPU intensive | Bloated tables |
+
+## Real-World Batch Processing Example
+
+```bash
+# 1. Export IDs
+psql -h db -U user -d mydb -c "\COPY (SELECT id FROM users WHERE active = false ORDER BY id) TO '/tmp/inactive_users.csv' CSV"
+
+# 2. Split into smaller files (optional for very large datasets)
+split -l 5000 /tmp/inactive_users.csv /tmp/batch_
+
+# 3. Process with script (Python example pattern)
+# - Read file/chunk
+# - Build explicit ID lists: UPDATE users SET deleted_at = NOW() WHERE id IN (1,2,3,4,5...)
+# - Commit every batch
+# - Log progress to file/table
+# - Sleep between batches
+# - Handle connection failures with retry
+```

--- a/scripts/generate-suggestions-doc.sh
+++ b/scripts/generate-suggestions-doc.sh
@@ -50,11 +50,25 @@ done
 # Remove trailing newline
 OPERATIONS_WITH_ALTERNATIVES_TABLE="${OPERATIONS_WITH_ALTERNATIVES_TABLE%$'\n'}"
 
-# Export all variables for envsubst
-export VERSION GENERATED_AT TOTAL_OPERATIONS WITH_ALTERNATIVES WITHOUT_ALTERNATIVES
-export WITH_ALTERNATIVES_PERCENT WITHOUT_ALTERNATIVES_PERCENT OPERATIONS_WITH_ALTERNATIVES_TABLE
-
-# Generate the documentation
-envsubst < "$TEMPLATE_FILE" > "$OUTPUT_FILE"
+# Generate the documentation using awk instead of envsubst
+awk -v version="$VERSION" \
+    -v generated_at="$GENERATED_AT" \
+    -v total_ops="$TOTAL_OPERATIONS" \
+    -v with_alt="$WITH_ALTERNATIVES" \
+    -v without_alt="$WITHOUT_ALTERNATIVES" \
+    -v with_alt_pct="$WITH_ALTERNATIVES_PERCENT" \
+    -v without_alt_pct="$WITHOUT_ALTERNATIVES_PERCENT" \
+    -v ops_table="$OPERATIONS_WITH_ALTERNATIVES_TABLE" \
+    '{
+        gsub(/\${VERSION}/, version);
+        gsub(/\${GENERATED_AT}/, generated_at);
+        gsub(/\${TOTAL_OPERATIONS}/, total_ops);
+        gsub(/\${WITH_ALTERNATIVES}/, with_alt);
+        gsub(/\${WITHOUT_ALTERNATIVES}/, without_alt);
+        gsub(/\${WITH_ALTERNATIVES_PERCENT}/, with_alt_pct);
+        gsub(/\${WITHOUT_ALTERNATIVES_PERCENT}/, without_alt_pct);
+        gsub(/\${OPERATIONS_WITH_ALTERNATIVES_TABLE}/, ops_table);
+        print
+    }' "$TEMPLATE_FILE" > "$OUTPUT_FILE"
 
 echo "Generated $OUTPUT_FILE with $TOTAL_OPERATIONS operations ($WITH_ALTERNATIVES with alternatives)"


### PR DESCRIPTION
## Summary

This PR implements a dual-mode CI workflow for automatically generating suggestions documentation:

1. **PR Preview Mode**: When `suggestions.yaml` changes in a PR, the workflow generates documentation and posts it as a comment for review
2. **Main Branch Mode**: After merge, the workflow generates and commits the documentation to the repository

## Changes

- Updated `.github/workflows/generate-docs.yml` to implement dual-mode functionality
- Modified `scripts/generate-suggestions-doc.sh` to use `awk` instead of `envsubst` for better portability
- Added error handling with clear feedback in PR comments
- Implemented size limits for large documentation (truncates at 60KB for GitHub comment limits)
- Removed all emojis from CI workflow output per user request

## Technical Details

### PR Preview Features
- Uses `peter-evans/find-comment` to avoid duplicate comments
- Shows full documentation preview in collapsible section
- Handles generation errors with helpful debugging information
- Warns when documentation is truncated due to size

### Main Branch Features
- Auto-commits generated documentation with `[skip ci]` tag to prevent loops
- Only commits when actual changes are detected
- Uses bot credentials for commits

## Testing

Tested locally with `gh act`:
- Script generates documentation correctly without `envsubst`
- Workflow structure validated (actual PR comment testing requires real PR context)

Fixes #17

## Next Steps

After this PR is merged, any changes to `suggestions.yaml` will:
1. Show a preview in PR comments during review
2. Automatically update `docs/design/suggestions.md` when merged to main